### PR TITLE
Using more portable header

### DIFF
--- a/PIC32MZ/ZorkPicUSB.c
+++ b/PIC32MZ/ZorkPicUSB.c
@@ -13,6 +13,9 @@ uint8_t m_ControlBuffer[MAX_CONTROL_LENGTH];
 uint16_t m_ControlLength;
 uint16_t m_ControlIndex;
 
+static void USBInitEndPoints();
+void (*USBInitEndpoints)() = &USBInitEndPoints;
+
 void USBInit() {
 
     USBOTGbits.BDEV = 0;
@@ -35,7 +38,7 @@ void USBInit() {
 
 }
 
-void USBInitEndpoints() {
+void USBInitEndPoints() {
 
     // TODO: endpoint length is not linked to config 
 

--- a/PIC32MZ/ZorkPicUSB.h
+++ b/PIC32MZ/ZorkPicUSB.h
@@ -1,7 +1,7 @@
 #ifndef ZORKPICUSB_H
 #define ZORKPICUSB_H
 
-#include "ZorkPicUSBConfig.h"
+#include <ZorkPicUSBConfig.h>
 #include <xc.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -14,7 +14,7 @@
 #define MAX_CONTROL_LENGTH 512
 
 void USBInit();
-void USBInitEndpoints();
+extern void (*USBInitEndpoints)();
 void USBService();
 
 void USBTransmit(uint8_t endpoint, uint8_t *data, uint16_t length);

--- a/PIC32MZ/ZorkPicUSB.h
+++ b/PIC32MZ/ZorkPicUSB.h
@@ -2,7 +2,7 @@
 #define ZORKPICUSB_H
 
 #include "ZorkPicUSBConfig.h"
-#include <proc/p32mz2048efh064.h>
+#include <xc.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
I was able to run your logic using PIC32MZ EF Curiosity Board. (PIC32MZ2048EFM100) I would like to be able to submodule your logic into my project, so that you get credit and the licenses are respected. This pull request enables a portable way of handling processor differences.

Thank you for this code. It saved me a lot of hassle.  